### PR TITLE
Add metaconfig flag

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,3 +10,6 @@ default_domain = default_domain
 scope = local
 # enable arping on container IFup
 auto_arp
+
+# Automatic container tracking for docker
+push_metaconfig

--- a/plugin/driver/config.go
+++ b/plugin/driver/config.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	vip        string
-	username   string
-	password   string
-	default_vd string
-	scope      string
-	auto_arp   bool = false
+	vip             string
+	username        string
+	password        string
+	default_vd      string
+	scope           string
+	auto_arp        bool = false
+	push_metaconfig bool = false
 )
 
 // Read configuration file
@@ -55,5 +56,6 @@ func ReadConfig() {
 	} else {
 		scope = lib_section.ValueOf("scope")
 		auto_arp = lib_section.Exists("auto_arp")
+		push_metaconfig = lib_section.Exists("push_metaconfig")
 	}
 }

--- a/plugin/driver/driver.go
+++ b/plugin/driver/driver.go
@@ -345,7 +345,9 @@ func (driver *driver) joinEndpoint(w http.ResponseWriter, r *http.Request) {
 		Gateway:       gatewayIP,
 	}
 
-	AddMetaconfig(domainid, bridgeID, j.SandboxKey[22:], endID, mac)
+	if push_metaconfig {
+		AddMetaconfig(domainid, bridgeID, j.SandboxKey[22:], endID, mac)
+	}
 
 	objectResponse(w, res)
 	Log.Infof("Join endpoint %s:%s to %s", j.NetworkID, j.EndpointID, j.SandboxKey)
@@ -419,7 +421,9 @@ func (driver *driver) leaveEndpoint(w http.ResponseWriter, r *http.Request) {
 		errorResponse(w, "Unable to off-board container from PLUMgrid")
 	}
 
-	RemoveMetaconfig(domainid, bridgeID, l.EndpointID)
+	if push_metaconfig {
+		RemoveMetaconfig(domainid, bridgeID, l.EndpointID)
+	}
 
 	emptyResponse(w)
 	Log.Infof("Leave %s:%s", l.NetworkID, l.EndpointID)


### PR DESCRIPTION
Allows activating or deactivating the automatic metaconfig population
for containers in PG premises.

Signed-off-by: eduards eduards@plumgrid.com
