### PR TITLE
GARP with Metadata

### DIFF
--- a/plugin/driver/pg_helper.go
+++ b/plugin/driver/pg_helper.go
@@ -345,7 +345,7 @@ func CheckNeChildList(NeID string, DomainID string, childList string) {
 	}
 }
 
-func AddMetaconfig(domainID string, netID string, deviceID string, endpointID string, macaddr string) {
+func AddMetaconfig(domainID string, netID string, deviceID string, endpointID string, macaddr string, ip string) {
 
 	url := "/0/tenant_manager/metaconfig/" + domainID + "?configonly=true"
 	body, _ := RestCall("GET", url, nil)
@@ -370,6 +370,7 @@ func AddMetaconfig(domainID string, netID string, deviceID string, endpointID st
 			 "prop": {
 				"` + endpointID + `": {
 						"phy_address": "` + macaddr + `",
+						"ip_address": "` + ip + `",
 						"hint": "` + netID + `"}}}`)
 	RestCall("PUT", url, data)
 }


### PR DESCRIPTION
- Push Metadata / GARP options still work one without the other.
- Makes sure it only writes metadata the first time it gets the IP.

Signed-off-by: eduards eduards@plumgrid.com
